### PR TITLE
Refine audience section and registration text

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,13 +285,13 @@
   <!-- AUDIENCE (updated) -->
   <section id="audience" class="py-20 bg-white">
     <div class="container px-6">
-      <div class="text-center mb-12">
-        <h2 class="section-title text-4xl md:text-5xl font-black mb-6">אם חזרת מהשירות, ואת/ה עדיין שם -</h2>
+      <div class="flex items-center justify-center flex-wrap gap-4 mb-12">
+        <h2 class="section-title text-4xl md:text-5xl font-black m-0">אם חזרת מהשירות, ואת/ה עדיין שם -</h2>
         <a href="#registration" class="btn-primary px-5 py-2 rounded-full font-semibold">צור קשר</a>
       </div>
 
-      <p class="mt-2 text-gray-700 text-center font-medium">הקול שלך חשוב. אנחנו מתחילים ממנו, תמיד.</p>
-      <p class="mt-2 text-gray-600 text-center">כל המגדרים, מגיל 20+. דגש על אמון, בטיחות וקצב אישי.</p>
+      <p class="mt-2 text-gray-700 text-center font-medium text-xl">הקול שלך חשוב. אנחנו מתחילים ממנו, תמיד.</p>
+      <p class="mt-2 text-gray-600 text-center text-xl">כל המגדרים, מגיל 20+. דגש על אמון, בטיחות וקצב אישי.</p>
     </div>
   </section>
 
@@ -338,8 +338,8 @@
   <section id="apply-process" class="py-20 bg-white">
     <div class="container px-6">
       <div class="text-center mb-12">
-        <h2 class="section-title text-4xl md:text-5xl font-black">תהליך הרשמה — חשוב מאוד</h2>
-        <p class="text-lg text-gray-700 max-w-3xl mx-auto mt-3">5 שלבים ברורים. אנחנו איתך צעד‑צעד. שכר הלימוד מסודר על ידך וההחזר מתבצע לפי נהלי אגף השיקום.</p>
+        <h2 class="section-title text-4xl md:text-5xl font-black">תהליך הרשמה</h2>
+        <p class="text-lg text-gray-700 max-w-3xl mx-auto mt-3">5 שלבים ברורים. אנחנו איתך צעד‑צעד.</p>
       </div>
       <div class="grid md:grid-cols-2 gap-10">
         <div class="card p-8 lift">
@@ -358,7 +358,6 @@
           <h3 class="font-extrabold text-xl mb-3">מה להכין לשיחה?</h3>
           <ul class="list-disc pr-6 text-gray-700 space-y-2">
             <li>כמה מילים עלייך ומה מושך אותך במדיה</li>
-            <li>אם יש — מספר ת״ז לצורך בדיקת זכאות</li>
             <li>לינקים לכל תוצר/קול/טקסט שכבר יצרת (לא חובה)</li>
           </ul>
           <div class="mt-6">


### PR DESCRIPTION
## Summary
- Align contact link with service-return heading and enlarge introductory statements
- Simplify registration process text and remove tuition details
- Drop ID-number requirement from call preparation list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a536b39c832f915d9de37738d382