### PR TITLE
Simplify social preview to show tagline and logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <!-- Social Preview (v2, cache-busted) -->
   <meta charset="utf-8">
   <title>הד בית מדיה שיקומי – אנו מהדהדים את קולך</title>
-  <meta name="description" content="הד בית מדיה שיקומי הוא מרחב בטוח שבו לומדים למצוא את הקול הפנימי ולהוציא אותו לעולם כחלק מתהליך שיקומי. יחד נלמד כיצד לקבל שליטה עצמית ולבנות אופק לעתיד, בקצב אישי ובליווי אנשי שיקום מומחי מדיה המובילים בתחום, תחת מעטפת של אנשי טיפול מומחים בפוסט-טראומה על רקע צבאי. בסיום התוכנית תוכלו להציג תיק עבודות, ביטחון מקצועי וקשרים אמיתיים.">
+  <meta name="description" content="אנו מהדהדים את קולך">
   <link rel="image_src" href="https://headtlv.netlify.app/assets/logo_head.png">
   <meta property="og:locale" content="he_IL">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="הד — בית מדיה שיקומי">
   <meta property="og:url" content="https://headtlv.netlify.app/?ts=20250909a">
   <meta property="og:title" content="הד בית מדיה שיקומי – אנו מהדהדים את קולך">
-  <meta property="og:description" content="הד בית מדיה שיקומי הוא מרחב בטוח שבו לומדים למצוא את הקול הפנימי ולהוציא אותו לעולם כחלק מתהליך שיקומי. יחד נלמד כיצד לקבל שליטה עצמית ולבנות אופק לעתיד, בקצב אישי ובליווי אנשי שיקום מומחי מדיה המובילים בתחום, תחת מעטפת של אנשי טיפול מומחים בפוסט-טראומה על רקע צבאי. בסיום התוכנית תוכלו להציג תיק עבודות, ביטחון מקצועי וקשרים אמיתיים.">
+  <meta property="og:description" content="אנו מהדהדים את קולך">
   <meta property="og:image" content="https://headtlv.netlify.app/assets/logo_head.png">
   <meta property="og:image:secure_url" content="https://headtlv.netlify.app/assets/logo_head.png">
   <meta property="og:image:type" content="image/png">
@@ -21,32 +21,10 @@
   <meta property="og:image:alt" content="לוגו הד — בית מדיה שיקומי">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="הד בית מדיה שיקומי – אנו מהדהדים את קולך">
-  <meta name="twitter:description" content="הד בית מדיה שיקומי הוא מרחב בטוח שבו לומדים למצוא את הקול הפנימי ולהוציא אותו לעולם כחלק מתהליך שיקומי. יחד נלמד כיצד לקבל שליטה עצמית ולבנות אופק לעתיד, בקצב אישי ובליווי אנשי שיקום מומחי מדיה המובילים בתחום, תחת מעטפת של אנשי טיפול מומחים בפוסט-טראומה על רקע צבאי. בסיום התוכנית תוכלו להציג תיק עבודות, ביטחון מקצועי וקשרים אמיתיים.">
+  <meta name="twitter:description" content="אנו מהדהדים את קולך">
   <meta name="twitter:image" content="https://headtlv.netlify.app/assets/logo_head.png">
   <meta name="robots" content="max-image-preview:large">
-
-
-  
-  <meta charset="utf-8">
-  <title>הד בית מדיה שיקומי – אנו מהדהדים את קולך</title>
-  <meta name="description" content="הד בית מדיה שיקומי הוא מרחב בטוח שבו לומדים למצוא את הקול הפנימי ולהוציא אותו לעולם כחלק מתהליך שיקומי. יחד נלמד כיצד לקבל שליטה עצמית ולבנות אופק לעתיד, בקצב אישי ובליווי אנשי שיקום מומחי מדיה המובילים בתחום, תחת מעטפת של אנשי טיפול מומחים בפוסט-טראומה על רקע צבאי. בסיום התוכנית תוכלו להציג תיק עבודות, ביטחון מקצועי וקשרים אמיתיים."/>
-  <meta property="og:locale" content="he_IL"/>
-  <meta property="og:type" content="website"/>
-  <meta property="og:site_name" content="הד — בית מדיה שיקומי"/>
-  <meta property="og:title" content="הד בית מדיה שיקומי – אנו מהדהדים את קולך"/>
-  <meta property="og:description" content="הד בית מדיה שיקומי הוא מרחב בטוח שבו לומדים למצוא את הקול הפנימי ולהוציא אותו לעולם כחלק מתהליך שיקומי. יחד נלמד כיצד לקבל שליטה עצמית ולבנות אופק לעתיד, בקצב אישי ובליווי אנשי שיקום מומחי מדיה המובילים בתחום, תחת מעטפת של אנשי טיפול מומחים בפוסט-טראומה על רקע צבאי. בסיום התוכנית תוכלו להציג תיק עבודות, ביטחון מקצועי וקשרים אמיתיים."/>
-  <meta property="og:image" content="https://headtlv.netlify.app/assets/logo_head.png"/>
-  <meta property="og:image" content="assets/logo_head.png"/>
-  <meta property="og:image:width" content="1200"/>
-  <meta property="og:image:height" content="630"/>
-  <meta name="twitter:card" content="summary_large_image"/>
-  <meta name="twitter:title" content="הד בית מדיה שיקומי – אנו מהדהדים את קולך"/>
-  <meta name="twitter:description" content="הד בית מדיה שיקומי הוא מרחב בטוח שבו לומדים למצוא את הקול הפנימי ולהוציא אותו לעולם כחלק מתהליך שיקומי. יחד נלמד כיצד לקבל שליטה עצמית ולבנות אופק לעתיד, בקצב אישי ובליווי אנשי שיקום מומחי מדיה המובילים בתחום, תחת מעטפת של אנשי טיפול מומחים בפוסט-טראומה על רקע צבאי. בסיום התוכנית תוכלו להציג תיק עבודות, ביטחון מקצועי וקשרים אמיתיים."/>
-  <meta name="twitter:image" content="assets/logo_head.png"/>
-
-  <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>הד — בית מדיה שיקומי</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
   <style>

--- a/share.html
+++ b/share.html
@@ -3,20 +3,20 @@
 <head>
   <meta charset="utf-8">
   <title>הד בית מדיה שיקומי – אנו מהדהדים את קולך</title>
-  <meta name="description" content="הד בית מדיה שיקומי הוא מרחב בטוח שבו לומדים למצוא את הקול הפנימי ולהוציא אותו לעולם כחלק מתהליך שיקומי. יחד נלמד כיצד לקבל שליטה עצמית ולבנות אופק לעתיד, בקצב אישי ובליווי אנשי שיקום מומחי מדיה המובילים בתחום, תחת מעטפת של אנשי טיפול מומחים בפוסט-טראומה על רקע צבאי. בסיום התוכנית תוכלו להציג תיק עבודות, ביטחון מקצועי וקשרים אמיתיים.">
+  <meta name="description" content="אנו מהדהדים את קולך">
   <meta property="og:locale" content="he_IL">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="הד — בית מדיה שיקומי">
   <meta property="og:url" content="https://headtlv.netlify.app/share.html?ts=20250909a">
   <meta property="og:title" content="הד בית מדיה שיקומי – אנו מהדהדים את קולך">
-  <meta property="og:description" content="הד בית מדיה שיקומי הוא מרחב בטוח שבו לומדים למצוא את הקול הפנימי ולהוציא אותו לעולם כחלק מתהליך שיקומי. יחד נלמד כיצד לקבל שליטה עצמית ולבנות אופק לעתיד, בקצב אישי ובליווי אנשי שיקום מומחי מדיה המובילים בתחום, תחת מעטפת של אנשי טיפול מומחים בפוסט-טראומה על רקע צבאי. בסיום התוכנית תוכלו להציג תיק עבודות, ביטחון מקצועי וקשרים אמיתיים.">
+  <meta property="og:description" content="אנו מהדהדים את קולך">
   <meta property="og:image" content="https://headtlv.netlify.app/assets/logo_head.png">
   <meta property="og:image:secure_url" content="https://headtlv.netlify.app/assets/logo_head.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="הד בית מדיה שיקומי – אנו מהדהדים את קולך">
-  <meta name="twitter:description" content="הד בית מדיה שיקומי הוא מרחב בטוח שבו לומדים למצוא את הקול הפנימי ולהוציא אותו לעולם כחלק מתהליך שיקומי. יחד נלמד כיצד לקבל שליטה עצמית ולבנות אופק לעתיד, בקצב אישי ובליווי אנשי שיקום מומחי מדיה המובילים בתחום, תחת מעטפת של אנשי טיפול מומחים בפוסט-טראומה על רקע צבאי. בסיום התוכנית תוכלו להציג תיק עבודות, ביטחון מקצועי וקשרים אמיתיים.">
+  <meta name="twitter:description" content="אנו מהדהדים את קולך">
   <meta name="twitter:image" content="https://headtlv.netlify.app/assets/logo_head.png">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>


### PR DESCRIPTION
## Summary
- streamline Open Graph and Twitter metadata to use short tagline and logo only
- remove duplicate social meta tags and extra titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2aae70db4832f9db298191978ed46